### PR TITLE
drm/gna: add basic debugfs interface

### DIFF
--- a/Documentation/gpu/gna.rst
+++ b/Documentation/gpu/gna.rst
@@ -1,0 +1,15 @@
+GNA DebugFS Interface
+=====================
+
+The GNA driver exposes a few runtime metrics through the DRM debugfs
+interface.  Once the driver is loaded, the following files appear under
+``/sys/kernel/debug/dri/<minor>/``::
+
+  hw_status
+     Current raw value of the hardware status register.
+
+  request_count
+     Total number of compute requests submitted to the hardware.
+
+These entries are read-only and intended for developers to inspect the
+state of the accelerator for debugging purposes.

--- a/drivers/gpu/drm/gna/gna_debugfs.c
+++ b/drivers/gpu/drm/gna/gna_debugfs.c
@@ -1,0 +1,36 @@
+#include <linux/seq_file.h>
+#include <drm/drm_debugfs.h>
+#include <drm/drm_device.h>
+
+#include "gna_debugfs.h"
+#include "gna_device.h"
+
+/*
+ * Simple debugfs support to expose a few runtime statistics about the
+ * device.  The hardware status register is reported along with the number
+ * of requests ever submitted to the engine.
+ */
+
+static int gna_hw_status_show(struct seq_file *m, void *data)
+{
+    struct gna_device *gna = m->private;
+
+    seq_printf(m, "0x%08x\n", gna->hw_status);
+    return 0;
+}
+
+static int gna_request_count_show(struct seq_file *m, void *data)
+{
+    struct gna_device *gna = m->private;
+
+    seq_printf(m, "%u\n", gna->request_count);
+    return 0;
+}
+
+static const struct drm_info_list gna_debugfs_entries[] = {
+    { "hw_status", gna_hw_status_show, 0, NULL },
+    { "request_count", gna_request_count_show, 0, NULL },
+};
+
+const struct drm_info_list *gna_debugfs_files = gna_debugfs_entries;
+const int gna_debugfs_file_count = ARRAY_SIZE(gna_debugfs_entries);

--- a/drivers/gpu/drm/gna/gna_debugfs.h
+++ b/drivers/gpu/drm/gna/gna_debugfs.h
@@ -1,0 +1,11 @@
+#ifndef _GNA_DEBUGFS_H_
+#define _GNA_DEBUGFS_H_
+
+#include <drm/drm_debugfs.h>
+
+struct gna_device;
+
+extern const struct drm_info_list *gna_debugfs_files;
+extern const int gna_debugfs_file_count;
+
+#endif /* _GNA_DEBUGFS_H_ */

--- a/drivers/gpu/drm/gna/gna_device.c
+++ b/drivers/gpu/drm/gna/gna_device.c
@@ -1,0 +1,44 @@
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <drm/drm_drv.h>
+#include <drm/drm_file.h>
+#include <drm/drm_device.h>
+#include <drm/drm_debugfs.h>
+
+#include "gna_device.h"
+#include "gna_debugfs.h"
+
+/* Simple stub probe function to illustrate debugfs registration */
+static int gna_probe(struct platform_device *pdev)
+{
+    struct gna_device *gna = devm_kzalloc(&pdev->dev, sizeof(*gna), GFP_KERNEL);
+    int ret;
+
+    if (!gna)
+        return -ENOMEM;
+
+    /* In a real driver this would set up hardware and register with DRM */
+    ret = drm_dev_init(&gna->ddev, NULL, &pdev->dev);
+    if (ret)
+        return ret;
+
+#ifdef CONFIG_DEBUG_FS
+    drm_debugfs_add_files(gna->ddev.primary, gna_debugfs_files,
+                          gna_debugfs_file_count);
+#endif
+
+    return 0;
+}
+
+static struct platform_driver gna_platform_driver = {
+    .probe = gna_probe,
+    .driver = {
+        .name = "gna",
+    },
+};
+
+module_platform_driver(gna_platform_driver);
+
+MODULE_AUTHOR("ChatGPT");
+MODULE_LICENSE("GPL");
+

--- a/drivers/gpu/drm/gna/gna_device.h
+++ b/drivers/gpu/drm/gna/gna_device.h
@@ -1,0 +1,12 @@
+#ifndef _GNA_DEVICE_H_
+#define _GNA_DEVICE_H_
+
+#include <drm/drm_device.h>
+
+struct gna_device {
+    struct drm_device ddev;
+    u32 hw_status;
+    u32 request_count;
+};
+
+#endif /* _GNA_DEVICE_H_ */


### PR DESCRIPTION
## Summary
- expose hardware status and request counters via debugfs
- hook up debugfs in GNA probe routine
- document available GNA debugfs files

## Testing
- `make help` *(fails: No rule to make target 'help')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2275b724832db88ea92f786888a4