### PR TITLE
Add userland GNA test tool

### DIFF
--- a/README
+++ b/README
@@ -76,3 +76,8 @@ make install
 
 # Note on additional patch set:
 # Another patch found in intel_gna set gives drivers/misc/intel_gna but is incompatible with v6.5.x kernel. It requires v5.x.x kernel.
+
+# Build and run the userland GNA tool
+cd userland
+make
+./gna_tool

--- a/userland/Makefile
+++ b/userland/Makefile
@@ -1,0 +1,12 @@
+CC ?= cc
+CFLAGS ?= -Wall -Wextra -O2
+
+all: gna_tool
+
+gna_tool: gna_tool.c gna_drm.h
+	$(CC) $(CFLAGS) -o $@ gna_tool.c
+
+clean:
+	rm -f gna_tool
+
+.PHONY: all clean

--- a/userland/gna_drm.h
+++ b/userland/gna_drm.h
@@ -1,0 +1,135 @@
+#ifndef _GNA_DRM_H_
+#define _GNA_DRM_H_
+
+#include <linux/types.h>
+#include <drm/drm.h>
+
+#ifndef _BITUL
+#define _BITUL(x) (1UL << (x))
+#endif
+
+#define GNA_PARAM_RECOVERY_TIMEOUT 1
+#define GNA_PARAM_DEVICE_TYPE 2
+#define GNA_PARAM_INPUT_BUFFER_S 3
+#define GNA_PARAM_DDI_VERSION 4
+
+#define GNA_STS_SCORE_COMPLETED _BITUL(0)
+#define GNA_STS_STATISTICS_VALID _BITUL(3)
+#define GNA_STS_PCI_MMU_ERR _BITUL(4)
+#define GNA_STS_PCI_DMA_ERR _BITUL(5)
+#define GNA_STS_PCI_UNEXCOMPL_ERR _BITUL(6)
+#define GNA_STS_VA_OOR _BITUL(7)
+#define GNA_STS_PARAM_OOR _BITUL(8)
+#define GNA_STS_SATURATE _BITUL(17)
+
+#define GNA_ERROR (GNA_STS_PCI_DMA_ERR | \
+                   GNA_STS_PCI_MMU_ERR | \
+                   GNA_STS_PCI_UNEXCOMPL_ERR | \
+                   GNA_STS_PARAM_OOR | \
+                   GNA_STS_VA_OOR)
+
+#define GNA_DEV_TYPE_0_9 0x09
+#define GNA_DEV_TYPE_1_0 0x10
+#define GNA_DEV_TYPE_2_0 0x20
+#define GNA_DEV_TYPE_3_0 0x30
+#define GNA_DEV_TYPE_3_5 0x35
+
+typedef __u64 gna_param_id;
+
+union gna_parameter {
+    struct {
+        gna_param_id id;
+    } in;
+    struct {
+        __u64 value;
+    } out;
+};
+
+struct gna_mem_id {
+    __u32 handle;
+    __u32 pad;
+    __u64 vma_fake_offset;
+    __u64 size_granted;
+};
+
+union gna_gem_new {
+    struct {
+        __u64 size;
+    } in;
+    struct gna_mem_id out;
+};
+
+struct gna_gem_free {
+    __u32 handle;
+    __u32 pad;
+};
+
+struct gna_buffer {
+    __u32 handle;
+    __u32 pad;
+    __u64 offset;
+    __u64 size;
+    __u64 patch_count;
+    __u64 patches_ptr;
+};
+
+struct gna_drv_perf {
+    __u64 pre_processing;
+    __u64 processing;
+    __u64 hw_completed;
+    __u64 completion;
+};
+
+struct gna_hw_perf {
+    __u64 total;
+    __u64 stall;
+};
+
+struct gna_compute_cfg {
+    __u32 layer_base;
+    __u32 layer_count;
+    __u64 buffers_ptr;
+    __u64 buffer_count;
+    __u8 active_list_on;
+    __u8 gna_mode;
+    __u8 hw_perf_encoding;
+    __u8 flags;
+    __u8 pad[4];
+};
+
+union gna_compute {
+    struct {
+        struct gna_compute_cfg config;
+    } in;
+    struct {
+        __u64 request_id;
+    } out;
+};
+
+union gna_wait {
+    struct {
+        __u64 request_id;
+        __u32 timeout;
+        __u32 pad;
+    } in;
+    struct {
+        __u32 hw_status;
+        __u32 pad;
+        struct gna_drv_perf drv_perf;
+        struct gna_hw_perf hw_perf;
+    } out;
+};
+
+#define DRM_GNA_GET_PARAMETER 0x00
+#define DRM_GNA_GEM_NEW 0x01
+#define DRM_GNA_GEM_FREE 0x02
+#define DRM_GNA_COMPUTE 0x03
+#define DRM_GNA_WAIT 0x04
+
+#define DRM_IOCTL_GNA_GET_PARAMETER DRM_IOWR(DRM_COMMAND_BASE + DRM_GNA_GET_PARAMETER, union gna_parameter)
+#define DRM_IOCTL_GNA_GEM_NEW DRM_IOWR(DRM_COMMAND_BASE + DRM_GNA_GEM_NEW, union gna_gem_new)
+#define DRM_IOCTL_GNA_GEM_FREE DRM_IOWR(DRM_COMMAND_BASE + DRM_GNA_GEM_FREE, struct gna_gem_free)
+#define DRM_IOCTL_GNA_COMPUTE DRM_IOWR(DRM_COMMAND_BASE + DRM_GNA_COMPUTE, union gna_compute)
+#define DRM_IOCTL_GNA_WAIT DRM_IOWR(DRM_COMMAND_BASE + DRM_GNA_WAIT, union gna_wait)
+
+#endif /* _GNA_DRM_H_ */

--- a/userland/gna_tool.c
+++ b/userland/gna_tool.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <glob.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "gna_drm.h"
+
+static int open_render_node(void)
+{
+    glob_t g;
+    int fd = -1;
+    if (glob("/dev/dri/renderD*", 0, NULL, &g) == 0) {
+        for (size_t i = 0; i < g.gl_pathc; ++i) {
+            fd = open(g.gl_pathv[i], O_RDWR);
+            if (fd >= 0) {
+                printf("Opened %s\n", g.gl_pathv[i]);
+                break;
+            }
+        }
+        globfree(&g);
+    }
+    if (fd < 0)
+        perror("open render node");
+    return fd;
+}
+
+int main(void)
+{
+    int fd = open_render_node();
+    if (fd < 0)
+        return 1;
+
+    union gna_parameter param;
+    memset(&param, 0, sizeof(param));
+    param.in.id = GNA_PARAM_DEVICE_TYPE;
+    if (ioctl(fd, DRM_IOCTL_GNA_GET_PARAMETER, &param) == 0)
+        printf("Device type: 0x%llx\n", (unsigned long long)param.out.value);
+    else
+        perror("DRM_IOCTL_GNA_GET_PARAMETER");
+
+    union gna_gem_new gem_new;
+    memset(&gem_new, 0, sizeof(gem_new));
+    gem_new.in.size = 4096;
+    if (ioctl(fd, DRM_IOCTL_GNA_GEM_NEW, &gem_new) == 0)
+        printf("Allocated GEM handle %u (%llu bytes)\n", gem_new.out.handle,
+               (unsigned long long)gem_new.out.size_granted);
+    else
+        perror("DRM_IOCTL_GNA_GEM_NEW");
+
+    struct gna_mem_id mem = gem_new.out;
+
+    struct gna_buffer buffer;
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.handle = mem.handle;
+    buffer.size = gem_new.out.size_granted;
+
+    struct gna_compute_cfg cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.buffers_ptr = (uintptr_t)&buffer;
+    cfg.buffer_count = 1;
+
+    union gna_compute comp;
+    memset(&comp, 0, sizeof(comp));
+    comp.in.config = cfg;
+    if (ioctl(fd, DRM_IOCTL_GNA_COMPUTE, &comp) == 0)
+        printf("Compute request id %llu\n", (unsigned long long)comp.out.request_id);
+    else
+        perror("DRM_IOCTL_GNA_COMPUTE");
+
+    union gna_wait wait;
+    memset(&wait, 0, sizeof(wait));
+    wait.in.request_id = comp.out.request_id;
+    wait.in.timeout = 1000; /* 1s */
+    if (ioctl(fd, DRM_IOCTL_GNA_WAIT, &wait) == 0)
+        printf("Wait hw_status 0x%x\n", wait.out.hw_status);
+    else
+        perror("DRM_IOCTL_GNA_WAIT");
+
+    struct gna_gem_free gem_free;
+    memset(&gem_free, 0, sizeof(gem_free));
+    gem_free.handle = mem.handle;
+    if (ioctl(fd, DRM_IOCTL_GNA_GEM_FREE, &gem_free) != 0)
+        perror("DRM_IOCTL_GNA_GEM_FREE");
+
+    close(fd);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `gna_drm.h` with user space definitions for GNA ioctls
- provide `gna_tool` utility that opens the render node and exercises key GNA ioctls
- document build and usage instructions in the top-level README

## Testing
- `cd userland && make`
- `./gna_tool` *(fails: open render node: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae23f11a78832da80d55e1734c788b