### PR TITLE
Add build system for GNA kernel module and userland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
+USERLAND_DIR := userland
+PREFIX ?= /usr/local
+
+.PHONY: all install kernel kernel_install userland userland_install test clean
+
+all: kernel userland
+
+install: kernel_install userland_install
+
+kernel:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna modules
+
+kernel_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna modules_install
+
+userland:
+	$(MAKE) -C $(USERLAND_DIR)
+
+userland_install:
+	install -D $(USERLAND_DIR)/gna_tool $(PREFIX)/bin/gna_tool
+
+test:
+	sudo modprobe gna
+	$(USERLAND_DIR)/gna_tool --version
+
+clean:
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna clean
+	$(MAKE) -C $(USERLAND_DIR) clean

--- a/README
+++ b/README
@@ -77,7 +77,11 @@ make install
 # Note on additional patch set:
 # Another patch found in intel_gna set gives drivers/misc/intel_gna but is incompatible with v6.5.x kernel. It requires v5.x.x kernel.
 
-# Build and run the userland GNA tool
-cd userland
+# Build kernel module and userland
 make
-./gna_tool
+
+# Install kernel module and userland tool
+sudo make install
+
+# Run basic test
+make test


### PR DESCRIPTION
## Summary
- provide top-level Makefile to build/install kernel module and userland tool
- document `make`, `make install`, and `make test` in README

## Testing
- `make -n` *(fails: No such file or directory)*
- `make test` *(fails: sudo: modprobe: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2717c5c4832db936afaaf08c07f5