### PR TITLE
Add DKMS configuration for GNA module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ PWD := $(shell pwd)
 USERLAND_DIR := userland
 PREFIX ?= /usr/local
 
+ifneq ($(KERNELRELEASE),)
+
+CONFIG_DRM_GNA := m
+obj-$(CONFIG_DRM_GNA) += drivers/gpu/drm/gna/
+
+else
+
 .PHONY: all install kernel kernel_install userland userland_install test clean
 
 all: kernel userland
@@ -10,10 +17,10 @@ all: kernel userland
 install: kernel_install userland_install
 
 kernel:
-	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
 
 kernel_install:
-	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna modules_install
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
 
 userland:
 	$(MAKE) -C $(USERLAND_DIR)
@@ -26,5 +33,7 @@ test:
 	$(USERLAND_DIR)/gna_tool --version
 
 clean:
-	$(MAKE) -C $(KERNEL_SRC) M=$(PWD)/drivers/gpu/drm/gna clean
+	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
 	$(MAKE) -C $(USERLAND_DIR) clean
+
+endif

--- a/README
+++ b/README
@@ -85,3 +85,15 @@ sudo make install
 
 # Run basic test
 make test
+
+## Building with DKMS
+
+The module can be built and installed for other kernels using [DKMS](https://github.com/dell/dkms). The following example builds for kernel version 6.12.43:
+
+```
+sudo dkms add .
+sudo dkms build gna/0.1 -k 6.12.43
+sudo dkms install gna/0.1 -k 6.12.43
+```
+
+Replace `6.12.43` with the kernel version you wish to target.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,11 @@
+PACKAGE_NAME="gna"
+PACKAGE_VERSION="0.1"
+
+BUILT_MODULE_NAME[0]="gna"
+BUILT_MODULE_LOCATION[0]="drivers/gpu/drm/gna"
+DEST_MODULE_LOCATION[0]="/updates"
+
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+
+AUTOINSTALL="yes"


### PR DESCRIPTION
## Summary
- add `dkms.conf` with build and clean instructions for the GNA driver
- update Makefile to support DKMS module builds
- document DKMS add/build/install workflow in README

## Testing
- `make clean` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2cc7a0dc832dbb65630fa4681feb