### PR TITLE
dkms: place module under drm directory

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -3,7 +3,7 @@ PACKAGE_VERSION="0.1"
 
 BUILT_MODULE_NAME[0]="gna"
 BUILT_MODULE_LOCATION[0]="drivers/gpu/drm/gna"
-DEST_MODULE_LOCATION[0]="/updates"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/gpu/drm"
 
 MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 CLEAN[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"


### PR DESCRIPTION
## Summary
- install DKMS module under kernel/drivers/gpu/drm

## Testing
- `dkms add .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae3295c974832d9a7943bb3a0adbaa