### PR TITLE
Improve userland build for GNA tool

### DIFF
--- a/README
+++ b/README
@@ -82,6 +82,7 @@ make install
 # Another patch found in intel_gna set gives drivers/misc/intel_gna but is incompatible with v6.5.x kernel. It requires v5.x.x kernel.
 
 # Build kernel module and userland
+# Requires libdrm development headers for the userland tool
 make
 
 # Install kernel module and userland tool

--- a/userland/Makefile
+++ b/userland/Makefile
@@ -1,10 +1,13 @@
 CC ?= cc
 CFLAGS ?= -Wall -Wextra -O2
+PKG_CONFIG ?= pkg-config
+LIBDRM_CFLAGS := $(shell $(PKG_CONFIG) --cflags libdrm 2>/dev/null)
+LIBDRM_LIBS := $(shell $(PKG_CONFIG) --libs libdrm 2>/dev/null)
 
 all: gna_tool
 
 gna_tool: gna_tool.c gna_drm.h
-	$(CC) $(CFLAGS) -o $@ gna_tool.c
+	$(CC) $(CFLAGS) $(LIBDRM_CFLAGS) -o $@ gna_tool.c $(LIBDRM_LIBS)
 
 clean:
 	rm -f gna_tool


### PR DESCRIPTION
## Summary
- use pkg-config to supply libdrm flags when building `gna_tool`
- document libdrm requirement for the userland utility

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*
- `make userland`


------
https://chatgpt.com/codex/tasks/task_e_68ae3449df04832db456e2fecec65868